### PR TITLE
Aded image manipulation protection

### DIFF
--- a/cdn/controllers/Blank_avatar.php
+++ b/cdn/controllers/Blank_avatar.php
@@ -39,9 +39,13 @@ class Blank_avatar extends Base
         // --------------------------------------------------------------------------
 
         //  Determine dynamic values
-        $this->width  = $this->uri->segment(3, 100);
-        $this->height = $this->uri->segment(4, 100);
+        $this->width  = (int) $this->uri->segment(3, 100);
+        $this->height = (int) $this->uri->segment(4, 100);
         $this->sex    = strtolower($this->uri->segment(5, 'neutral'));
+
+        // --------------------------------------------------------------------------
+
+        $this->checkDimensions($this->width, $this->height);
 
         // --------------------------------------------------------------------------
 
@@ -87,7 +91,6 @@ class Blank_avatar extends Base
          */
 
         if ($this->serveNotModified($this->cdnCacheFile)) {
-
             return;
         }
 
@@ -161,10 +164,10 @@ class Blank_avatar extends Base
 
                 //  This object does not exist.
                 log_message('error', 'CDN: Blank Avatar: File not found; ' . $src);
-                return $this->serveBadSrc( [
-                    'width' => $width,
-                    'height' => $height
-                ] );
+                return $this->serveBadSrc([
+                    'width'  => $width,
+                    'height' => $height,
+                ]);
             }
         }
     }

--- a/cdn/controllers/Crop.php
+++ b/cdn/controllers/Crop.php
@@ -35,11 +35,15 @@ class Crop extends Base
 
         //  Determine dynamic values
         $oUri            = Factory::service('Uri');
-        $this->width     = $oUri->segment(3, 100);
-        $this->height    = $oUri->segment(4, 100);
+        $this->width     = (int) $oUri->segment(3, 100);
+        $this->height    = (int) $oUri->segment(4, 100);
         $this->bucket    = $oUri->segment(5);
         $this->object    = urldecode($oUri->segment(6));
         $this->extension = !empty($this->object) ? strtolower(substr($this->object, strrpos($this->object, '.'))) : '';
+
+        // --------------------------------------------------------------------------
+
+        $this->checkDimensions($this->width, $this->height);
 
         // --------------------------------------------------------------------------
 

--- a/cdn/controllers/Placeholder.php
+++ b/cdn/controllers/Placeholder.php
@@ -34,9 +34,13 @@ class Placeholder extends Base
         $this->tile = $this->cdnRoot . '_resources/img/placeholder.png';
 
         //  Determine dynamic values
-        $this->width  = $this->uri->segment(3, 100);
-        $this->height = $this->uri->segment(4, 100);
+        $this->width  = (int) $this->uri->segment(3, 100);
+        $this->height = (int) $this->uri->segment(4, 100);
         $this->border = $this->uri->segment(5, 1);
+
+        // --------------------------------------------------------------------------
+
+        $this->checkDimensions($this->width, $this->height);
 
         // --------------------------------------------------------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,15 @@
                             ]
                         }
                     }
+                },
+                "nailsapp/module-cdn": {
+                    "permitted-image-dimensions": [
+                        "100x100",
+                        "400x400"
+                    ]
                 }
             }
+
         }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,9 @@
 
 This module brings file management and image manipulation to Nails. Can be configured to use the local filesystem, or remote services for truly distributed content.
 
-- [Drivers](/docs/drivers/README.md)
-- [Console](/docs/console/README.md)
+- [Drivers](drivers/README.md)
+- [Console](console/README.md)
+- [Image Transformation](console/README.md)
+    - [Cropping](transformation/cropping.md)
+    - [Scaling](transformation/scaling.md)
+    - [Security](transformation/security.md)

--- a/docs/transformation/cropping.md
+++ b/docs/transformation/cropping.md
@@ -1,0 +1,6 @@
+# Image Transformation: Cropping
+> Documentation is a WIP.
+
+Images stored in the CDN can be eaisly cropped.
+
+> @todo - write this

--- a/docs/transformation/scaling.md
+++ b/docs/transformation/scaling.md
@@ -1,0 +1,6 @@
+# Image Transformation: Scaling
+> Documentation is a WIP.
+
+Images stored in the CDN can be eaisly scaled to fit within certain boundaries.
+
+> @todo - write this

--- a/docs/transformation/security.md
+++ b/docs/transformation/security.md
@@ -1,0 +1,43 @@
+# Image Transformation: Security
+> Documentation is a WIP.
+
+Whilst image manipulation via the URL is incredibly useful it is quite dangerous to leave this open. An abuser could quite quickly overwhelm the server by generating many variations of an image.
+
+
+## Restricting Image Transformation
+
+All components, including the application, must explicitly announce the image dimensions they wish the CDN to honour; this is done in each component's `composer.json` file:
+
+```json
+{
+    "extra": {
+        "nails": {
+            "data": {
+                "nailsapp/module-cdn": {
+                    "permitted-image-dimensions": [
+                        "120x120",
+                        "250x250"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+The array will accept values which match the following regexes:
+
+- `/^\dx\d$/i`
+- `/^\d$/`
+
+You may also pass an array, where the first element is the width as an integer, and the second is the height as an integer.
+
+If a value cannot be parsed then a `\Nails\Cdn\Exception\PermittedDimensionException` exception will be thrown. This exception will also be thrown if you attempt to generate, or visit, a URL which results in an invalid dimension being requested.
+
+> Note; when in PRODUCTION an exception will **not** be thrown when visiting an invalid URL, instead the user will receive a 404.
+
+
+
+## Disabling Restrictions
+
+If you absoloutely must disable this security measure, then you may do so by setting the module's  `allowDangerousImageTransformation` service property to `true`.

--- a/services/services.php
+++ b/services/services.php
@@ -1,13 +1,13 @@
 <?php
 
-return array(
-    'properties' => array(
+return [
+    'properties' => [
 
         /**
          * Define the default array of allowed types/extensions
          * This list should be restrictive enough so that malicious users can't do too much damage.
          */
-        'bucketDefaultAllowedTypes' => array(
+        'bucketDefaultAllowedTypes' => [
             //  Images
             'png', 'jpg', 'gif',
             //  Documents & Text
@@ -17,34 +17,40 @@ return array(
             //  Audio
             'mp3', 'wav', 'aiff', 'ogg', 'm4a', 'wma', 'aac', 'oga',
             //  Zips
-            'zip'
-        )
-    ),
-    'services' => array(
+            'zip',
+        ],
+
+        /**
+         * Allow images to be manipulated to any size via the URL. Not recommended.
+         * https://github.com/nailsapp/module-cdn/blob/develop/docs/transformation/security.md
+         */
+        'allowDangerousImageTransformation' => false,
+    ],
+    'services'   => [
         'Cdn' => function () {
             if (class_exists('\App\Cdn\Service\Cdn')) {
                 return new \App\Cdn\Service\Cdn();
             } else {
                 return new \Nails\Cdn\Service\Cdn();
             }
-        }
-    ),
-    'models' => array(
-        'Bucket' => function () {
+        },
+    ],
+    'models'     => [
+        'Bucket'        => function () {
             if (class_exists('\App\Cdn\Model\Bucket')) {
                 return new \App\Cdn\Model\Bucket();
             } else {
                 return new \Nails\Cdn\Model\Bucket();
             }
         },
-        'Object' => function () {
+        'Object'        => function () {
             if (class_exists('\App\Cdn\Model\CdnObject')) {
                 return new \App\Cdn\Model\CdnObject();
             } else {
                 return new \Nails\Cdn\Model\CdnObject();
             }
         },
-        'ObjectTrash' => function () {
+        'ObjectTrash'   => function () {
             if (class_exists('\App\Cdn\Model\CdnObject\Trash')) {
                 return new \App\Cdn\Model\CdnObject\Trash();
             } else {
@@ -58,5 +64,5 @@ return array(
                 return new \Nails\Cdn\Model\StorageDriver();
             }
         },
-    )
-);
+    ],
+];

--- a/src/Exception/PermittedDimensionException.php
+++ b/src/Exception/PermittedDimensionException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Permitted Dimension Exception
+ *
+ * @package     Nails
+ * @subpackage  module-cdn
+ * @category    Exceptions
+ * @author      Nails Dev Team
+ * @link
+ */
+
+namespace Nails\Cdn\Exception;
+
+class PermittedDimensionException extends CdnException
+{
+}


### PR DESCRIPTION
Modules, and the app, must now explicitly specify what sizes they would like the CDN to honour when manipulating URLs.