### PR TITLE
Feat: JIT URL generation

### DIFF
--- a/helpers/cdn.php
+++ b/helpers/cdn.php
@@ -11,6 +11,7 @@
  */
 
 use Nails\Cdn\Constants;
+use Nails\Cdn\Resource\UrlGenerator;
 use Nails\Cdn\Service\Cdn;
 use Nails\Common\Service\View;
 use Nails\Factory;
@@ -121,9 +122,9 @@ if (!function_exists('cdnServe')) {
      * @param integer $iObjectId      The ID of the object to serve
      * @param boolean $bForceDownload Whether or not the URL should stream to the browser, or forcibly download
      *
-     * @return string
+     * @return UrlGenerator\Crop
      */
-    function cdnServe($iObjectId, $bForceDownload = false)
+    function cdnServe($iObjectId, $bForceDownload = false): UrlGenerator\Serve
     {
         /** @var Cdn $oCdn */
         $oCdn = Factory::service('Cdn', Constants::MODULE_SLUG);
@@ -181,9 +182,9 @@ if (!function_exists('cdnCrop')) {
      * @param integer $iWidth    The width of the thumbnail
      * @param integer $iHeight   The height of the thumbnail
      *
-     * @return string
+     * @return UrlGenerator\Crop
      */
-    function cdnCrop($iObjectId, $iWidth, $iHeight)
+    function cdnCrop($iObjectId, $iWidth, $iHeight): UrlGenerator\Crop
     {
         /** @var Cdn $oCdn */
         $oCdn = Factory::service('Cdn', Constants::MODULE_SLUG);
@@ -204,7 +205,7 @@ if (!function_exists('cdnScale')) {
      *
      * @return string
      */
-    function cdnScale($iObjectId, $iWidth, $iHeight)
+    function cdnScale($iObjectId, $iWidth, $iHeight): UrlGenerator\Scale
     {
         /** @var Cdn $oCdn */
         $oCdn = Factory::service('Cdn', Constants::MODULE_SLUG);

--- a/helpers/cdn.php
+++ b/helpers/cdn.php
@@ -21,8 +21,8 @@ if (!function_exists('formatBytes')) {
     /**
      * Formats a filesize given in bytes into a human-friendly string
      *
-     * @param integer $iBytes     The filesize, in bytes
-     * @param integer $iPrecision The precision to use
+     * @param int $iBytes     The filesize, in bytes
+     * @param int $iPrecision The precision to use
      *
      * @return string
      */
@@ -44,7 +44,7 @@ if (!function_exists('returnBytes')) {
      *
      * @param string $sSize The string to convert to bytes
      *
-     * @return integer
+     * @return int
      */
     function returnBytes($sSize): int
     {
@@ -62,9 +62,9 @@ if (!function_exists('maxUploadSize')) {
      * Returns the configured maximum upload size for this system by inspecting
      * upload_max_filesize and post_max_size, if available.
      *
-     * @param boolean $bFormat Whether to format the string using formatBytes
+     * @param bool $bFormat Whether to format the string using formatBytes
      *
-     * @return integer|string
+     * @return int|string
      */
     function maxUploadSize($bFormat = true)
     {
@@ -81,7 +81,7 @@ if (!function_exists('cdnObject')) {
     /**
      * Returns a CDN object
      *
-     * @param integer $iObjectId The ID of the object to get
+     * @param int $iObjectId The ID of the object to get
      *
      * @return stdClass
      */
@@ -100,7 +100,7 @@ if (!function_exists('cdnBucket')) {
     /**
      * Returns a CDN object
      *
-     * @param integer $iBucketId The ID of the bucket to get
+     * @param int $iBucketId The ID of the bucket to get
      *
      * @return stdClass
      */
@@ -119,12 +119,12 @@ if (!function_exists('cdnServe')) {
     /**
      * Returns the URL for serving raw content from the CDN
      *
-     * @param integer $iObjectId      The ID of the object to serve
-     * @param boolean $bForceDownload Whether or not the URL should stream to the browser, or forcibly download
+     * @param int  $iObjectId      The ID of the object to serve
+     * @param bool $bForceDownload Whether or not the URL should stream to the browser, or forcibly download
      *
-     * @return UrlGenerator\Crop
+     * @return UrlGenerator\Crop|null
      */
-    function cdnServe($iObjectId, $bForceDownload = false): UrlGenerator\Serve
+    function cdnServe($iObjectId, $bForceDownload = false): ?UrlGenerator\Serve
     {
         /** @var Cdn $oCdn */
         $oCdn = Factory::service('Cdn', Constants::MODULE_SLUG);
@@ -139,7 +139,7 @@ if (!function_exists('cdnServeRaw')) {
     /**
      * Returns the URL for serving raw content from the CDN driver's source and not running it through the main CDN
      *
-     * @param integer $iObjectId The ID of the object to serve
+     * @param int $iObjectId The ID of the object to serve
      *
      * @return string
      */
@@ -178,13 +178,13 @@ if (!function_exists('cdnCrop')) {
     /**
      * Returns the URL for a crop of an object
      *
-     * @param integer $iObjectId The Object's ID
-     * @param integer $iWidth    The width of the thumbnail
-     * @param integer $iHeight   The height of the thumbnail
+     * @param int $iObjectId The Object's ID
+     * @param int $iWidth    The width of the thumbnail
+     * @param int $iHeight   The height of the thumbnail
      *
-     * @return UrlGenerator\Crop
+     * @return UrlGenerator\Crop|null
      */
-    function cdnCrop($iObjectId, $iWidth, $iHeight): UrlGenerator\Crop
+    function cdnCrop($iObjectId, $iWidth, $iHeight): ?UrlGenerator\Crop
     {
         /** @var Cdn $oCdn */
         $oCdn = Factory::service('Cdn', Constants::MODULE_SLUG);
@@ -199,13 +199,13 @@ if (!function_exists('cdnScale')) {
     /**
      * Returns the URL for a scaled thumbnail of an object
      *
-     * @param integer $iObjectId The Object's ID
-     * @param integer $iWidth    The width of the thumbnail
-     * @param integer $iHeight   The height of the thumbnail
+     * @param int $iObjectId The Object's ID
+     * @param int $iWidth    The width of the thumbnail
+     * @param int $iHeight   The height of the thumbnail
      *
      * @return string
      */
-    function cdnScale($iObjectId, $iWidth, $iHeight): UrlGenerator\Scale
+    function cdnScale($iObjectId, $iWidth, $iHeight): ?UrlGenerator\Scale
     {
         /** @var Cdn $oCdn */
         $oCdn = Factory::service('Cdn', Constants::MODULE_SLUG);
@@ -220,9 +220,9 @@ if (!function_exists('cdnPlaceholder')) {
     /**
      * Returns the URL for a placeholder graphic
      *
-     * @param integer $iWidth  The width of the placeholder
-     * @param integer $iHeight The height of the placeholder
-     * @param integer $iBorder The width of the border, if any
+     * @param int $iWidth  The width of the placeholder
+     * @param int $iHeight The height of the placeholder
+     * @param int $iBorder The width of the border, if any
      *
      * @return string
      */
@@ -241,9 +241,9 @@ if (!function_exists('cdnBlankAvatar')) {
     /**
      * Returns the URL for a blank avatar graphic
      *
-     * @param integer        $iWidth  The width of the placeholder
-     * @param integer        $iHeight The height of the placeholder
-     * @param string|integer $mSex    The gender of the avatar
+     * @param int        $iWidth  The width of the placeholder
+     * @param int        $iHeight The height of the placeholder
+     * @param string|int $mSex    The gender of the avatar
      *
      * @return string
      */
@@ -262,9 +262,9 @@ if (!function_exists('cdnAvatar')) {
     /**
      * Returns the URL for a user's avatar
      *
-     * @param integer $iUserId The user ID to use
-     * @param integer $iWidth  The width of the avatar
-     * @param integer $iHeight The height of the avatar
+     * @param int $iUserId The user ID to use
+     * @param int $iWidth  The width of the avatar
+     * @param int $iHeight The height of the avatar
      *
      * @return string
      */
@@ -283,9 +283,9 @@ if (!function_exists('cdnExpiringUrl')) {
     /**
      * Returns an expiring URL
      *
-     * @param integer $iObject        The ID of the object to server
-     * @param integer $iExpires       The length of time the URL should be valid for, in seconds
-     * @param boolean $bForceDownload Whether or not the URL should stream to the browser, or forcibly download
+     * @param int  $iObject        The ID of the object to server
+     * @param int  $iExpires       The length of time the URL should be valid for, in seconds
+     * @param bool $bForceDownload Whether or not the URL should stream to the browser, or forcibly download
      *
      * @return string
      */
@@ -361,12 +361,12 @@ if (!function_exists('cdnObjectPicker')) {
     /**
      * Returns the markup required for cdn Object Pickers
      *
-     * @param string  $sKey       The name to give the input
-     * @param string  $sBucket    The bucket we're picking from
-     * @param int     $iObjectId  The object which has previously been chosen
-     * @param string  $sAttr      Any attributes to add to the containing element
-     * @param string  $sInputAttr Any attributes to add to the input element
-     * @param boolean $bReadOnly  Whether picker is readonly
+     * @param string $sKey       The name to give the input
+     * @param string $sBucket    The bucket we're picking from
+     * @param int    $iObjectId  The object which has previously been chosen
+     * @param string $sAttr      Any attributes to add to the containing element
+     * @param string $sInputAttr Any attributes to add to the input element
+     * @param bool   $bReadOnly  Whether picker is readonly
      *
      * @return string
      */

--- a/services/services.php
+++ b/services/services.php
@@ -1,6 +1,9 @@
 <?php
 
-use Nails\Common\Service;
+use Nails\Common;
+use Nails\Cdn\Resource;
+use Nails\Cdn\Service;
+use Nails\Cdn\Model;
 use Nails\Factory;
 
 return [
@@ -10,15 +13,43 @@ return [
          * Define the default array of allowed types/extensions
          * This list should be restrictive enough so that malicious users can't do too much damage.
          */
-        'bucketDefaultAllowedTypes' => [
+        'bucketDefaultAllowedTypes'         => [
             //  Images
-            'png', 'jpg', 'gif',
+            'png',
+            'jpg',
+            'gif',
             //  Documents & Text
-            'pdf', 'doc', 'docx', 'ppt', 'pptx', 'xls', 'xlsx', 'rtf', 'txt', 'csv', 'xml', 'json', 'js', 'css',
+            'pdf',
+            'doc',
+            'docx',
+            'ppt',
+            'pptx',
+            'xls',
+            'xlsx',
+            'rtf',
+            'txt',
+            'csv',
+            'xml',
+            'json',
+            'js',
+            'css',
             //  Video
-            'mp4', 'mov', 'm4v', 'mpg', 'mpeg', 'avi', 'ogv',
+            'mp4',
+            'mov',
+            'm4v',
+            'mpg',
+            'mpeg',
+            'avi',
+            'ogv',
             //  Audio
-            'mp3', 'wav', 'aiff', 'ogg', 'm4a', 'wma', 'aac', 'oga',
+            'mp3',
+            'wav',
+            'aiff',
+            'ogg',
+            'm4a',
+            'wma',
+            'aac',
+            'oga',
             //  Zips
             'zip',
         ],
@@ -34,26 +65,31 @@ return [
          *
          * @var int
          */
-        'trashRetention' => 180
+        'trashRetention'                    => 180,
     ],
     'services'   => [
-        'Cdn'           => function (Service\Mime $oMimeService = null) {
+        'Cdn'           => function (Common\Service\Mime $oMimeService = null): Service\Cdn {
 
-            if (!$oMimeService) {
-                $oMimeService = Factory::service('Mime');
-            }
+            $oMimeService = $oMimeService ?? Factory::service('Mime');
 
             if (class_exists('\App\Cdn\Service\Cdn')) {
                 return new \App\Cdn\Service\Cdn($oMimeService);
             } else {
-                return new \Nails\Cdn\Service\Cdn($oMimeService);
+                return new Service\Cdn($oMimeService);
             }
         },
-        'StorageDriver' => function () {
+        'StorageDriver' => function (): Service\StorageDriver {
             if (class_exists('\App\Cdn\Service\StorageDriver')) {
                 return new \App\Cdn\Service\StorageDriver();
             } else {
-                return new \Nails\Cdn\Service\StorageDriver();
+                return new Service\StorageDriver();
+            }
+        },
+        'UrlGenerator'  => function (): Service\UrlGenerator {
+            if (class_exists('\App\Cdn\Service\UrlGenerator')) {
+                return new \App\Cdn\Service\UrlGenerator();
+            } else {
+                return new Service\UrlGenerator();
             }
         },
     ],
@@ -62,87 +98,121 @@ return [
             if (class_exists('\App\Cdn\Model\Bucket')) {
                 return new \App\Cdn\Model\Bucket();
             } else {
-                return new \Nails\Cdn\Model\Bucket();
+                return new Model\Bucket();
             }
         },
         'Object'      => function () {
             if (class_exists('\App\Cdn\Model\CdnObject')) {
                 return new \App\Cdn\Model\CdnObject();
             } else {
-                return new \Nails\Cdn\Model\CdnObject();
+                return new Model\CdnObject();
             }
         },
         'ObjectTrash' => function () {
             if (class_exists('\App\Cdn\Model\CdnObject\Trash')) {
                 return new \App\Cdn\Model\CdnObject\Trash();
             } else {
-                return new \Nails\Cdn\Model\CdnObject\Trash();
+                return new Model\CdnObject\Trash();
             }
         },
         'Token'       => function () {
             if (class_exists('\App\Cdn\Model\Token')) {
                 return new \App\Cdn\Model\Token();
             } else {
-                return new \Nails\Cdn\Model\Token();
+                return new Model\Token();
             }
         },
     ],
-    'resources' => [
-        'Bucket'         => function ($oObj) {
+    'resources'  => [
+        'Bucket'            => function ($oObj): Resource\Bucket {
             if (class_exists('\App\Cdn\Resource\Bucket')) {
                 return new \App\Cdn\Resource\Bucket($oObj);
             } else {
-                return new \Nails\Cdn\Resource\Bucket($oObj);
+                return new Resource\Bucket($oObj);
             }
         },
-        'Object'         => function ($oObj) {
+        'Object'            => function ($oObj): Resource\CdnObject {
             if (class_exists('\App\Cdn\Resource\CdnObject')) {
                 return new \App\Cdn\Resource\CdnObject($oObj);
             } else {
-                return new \Nails\Cdn\Resource\CdnObject($oObj);
+                return new Resource\CdnObject($oObj);
             }
         },
-        'ObjectFile'     => function ($oObj) {
+        'ObjectFile'        => function ($oObj): Resource\CdnObject\File {
             if (class_exists('\App\Cdn\Resource\CdnObject\File')) {
                 return new \App\Cdn\Resource\CdnObject\File($oObj);
             } else {
-                return new \Nails\Cdn\Resource\CdnObject\File($oObj);
+                return new Resource\CdnObject\File($oObj);
             }
         },
-        'ObjectFileName' => function ($oObj) {
+        'ObjectFileName'    => function ($oObj): Resource\CdnObject\File\Name {
             if (class_exists('\App\Cdn\Resource\CdnObject\File\Name')) {
                 return new \App\Cdn\Resource\CdnObject\File\Name($oObj);
             } else {
-                return new \Nails\Cdn\Resource\CdnObject\File\Name($oObj);
+                return new Resource\CdnObject\File\Name($oObj);
             }
         },
-        'ObjectFileSize' => function ($oObj) {
+        'ObjectFileSize'    => function ($oObj): Resource\CdnObject\File\Size {
             if (class_exists('\App\Cdn\Resource\CdnObject\File\Size')) {
                 return new \App\Cdn\Resource\CdnObject\File\Size($oObj);
             } else {
-                return new \Nails\Cdn\Resource\CdnObject\File\Size($oObj);
+                return new Resource\CdnObject\File\Size($oObj);
             }
         },
-        'ObjectImage'    => function ($oObj) {
+        'ObjectImage'       => function ($oObj): Resource\CdnObject\Image {
             if (class_exists('\App\Cdn\Resource\CdnObject\Image')) {
                 return new \App\Cdn\Resource\CdnObject\Image($oObj);
             } else {
-                return new \Nails\Cdn\Resource\CdnObject\Image($oObj);
+                return new Resource\CdnObject\Image($oObj);
             }
         },
-        'ObjectUrl'      => function ($oObj) {
+        'ObjectUrl'         => function ($oObj): Resource\CdnObject\Url {
             if (class_exists('\App\Cdn\Resource\CdnObject\Url')) {
                 return new \App\Cdn\Resource\CdnObject\Url($oObj);
             } else {
-                return new \Nails\Cdn\Resource\CdnObject\Url($oObj);
+                return new Resource\CdnObject\Url($oObj);
             }
         },
-        'Token'          => function ($oObj) {
+        'Token'             => function ($oObj): Resource\Token {
             if (class_exists('\App\Cdn\Resource\Token')) {
                 return new \App\Cdn\Resource\Token($oObj);
             } else {
-                return new \Nails\Cdn\Resource\Token($oObj);
+                return new Resource\Token($oObj);
             }
         },
-    ]
+        'UrlGeneratorCrop'  => function (
+            Service\UrlGenerator $oSerice,
+            int $iObjectId,
+            int $iWidth,
+            int $iHeight
+        ): Resource\UrlGenerator\Crop {
+            if (class_exists('\App\Cdn\Resource\UrlGenerator\Crop')) {
+                return new \App\Cdn\Resource\UrlGenerator\Crop($oSerice, $iObjectId, $iWidth, $iHeight);
+            } else {
+                return new Resource\UrlGenerator\Crop($oSerice, $iObjectId, $iWidth, $iHeight);
+            }
+        },
+        'UrlGeneratorScale' => function (
+            Service\UrlGenerator $oSerice,
+            int $iObjectId,
+            int $iWidth,
+            int $iHeight
+        ): Resource\UrlGenerator\Scale {
+            if (class_exists('\App\Cdn\Resource\UrlGenerator\Scale')) {
+                return new \App\Cdn\Resource\UrlGenerator\Scale($oSerice, $iObjectId, $iWidth, $iHeight);
+            } else {
+                return new Resource\UrlGenerator\Scale($oSerice, $iObjectId, $iWidth, $iHeight);
+            }
+        },
+        'UrlGeneratorServe' => function (
+            Service\UrlGenerator $oSerice,
+            int $iObjectId
+        ): Resource\UrlGenerator\Serve {
+            if (class_exists('\App\Cdn\Resource\UrlGenerator\Serve')) {
+                return new \App\Cdn\Resource\UrlGenerator\Serve($oSerice, $iObjectId);
+            } else {
+                return new Resource\UrlGenerator\Serve($oSerice, $iObjectId);
+            }
+        },
+    ],
 ];

--- a/services/services.php
+++ b/services/services.php
@@ -173,6 +173,13 @@ return [
                 return new Resource\CdnObject\Url($oObj);
             }
         },
+        'ObjectTrash'       => function ($oObj): Resource\CdnObject {
+            if (class_exists('\App\Cdn\Resource\CdnObject\Trash')) {
+                return new \App\Cdn\Resource\CdnObject\Trash($oObj);
+            } else {
+                return new Resource\CdnObject\Trash($oObj);
+            }
+        },
         'Token'             => function ($oObj): Resource\Token {
             if (class_exists('\App\Cdn\Resource\Token')) {
                 return new \App\Cdn\Resource\Token($oObj);

--- a/services/services.php
+++ b/services/services.php
@@ -181,37 +181,41 @@ return [
             }
         },
         'UrlGeneratorCrop'  => function (
-            Service\UrlGenerator $oSerice,
+            Service\Cdn $oCdn,
+            Service\UrlGenerator $oService,
             int $iObjectId,
             int $iWidth,
             int $iHeight
         ): Resource\UrlGenerator\Crop {
             if (class_exists('\App\Cdn\Resource\UrlGenerator\Crop')) {
-                return new \App\Cdn\Resource\UrlGenerator\Crop($oSerice, $iObjectId, $iWidth, $iHeight);
+                return new \App\Cdn\Resource\UrlGenerator\Crop($oCdn, $oService, $iObjectId, $iWidth, $iHeight);
             } else {
-                return new Resource\UrlGenerator\Crop($oSerice, $iObjectId, $iWidth, $iHeight);
+                return new Resource\UrlGenerator\Crop($oCdn, $oService, $iObjectId, $iWidth, $iHeight);
             }
         },
         'UrlGeneratorScale' => function (
-            Service\UrlGenerator $oSerice,
+            Service\Cdn $oCdn,
+            Service\UrlGenerator $oService,
             int $iObjectId,
             int $iWidth,
             int $iHeight
         ): Resource\UrlGenerator\Scale {
             if (class_exists('\App\Cdn\Resource\UrlGenerator\Scale')) {
-                return new \App\Cdn\Resource\UrlGenerator\Scale($oSerice, $iObjectId, $iWidth, $iHeight);
+                return new \App\Cdn\Resource\UrlGenerator\Scale($oCdn, $oService, $iObjectId, $iWidth, $iHeight);
             } else {
-                return new Resource\UrlGenerator\Scale($oSerice, $iObjectId, $iWidth, $iHeight);
+                return new Resource\UrlGenerator\Scale($oCdn, $oService, $iObjectId, $iWidth, $iHeight);
             }
         },
         'UrlGeneratorServe' => function (
-            Service\UrlGenerator $oSerice,
-            int $iObjectId
+            Service\Cdn $oCdn,
+            Service\UrlGenerator $oService,
+            int $iObjectId,
+            bool $bForceDownload
         ): Resource\UrlGenerator\Serve {
             if (class_exists('\App\Cdn\Resource\UrlGenerator\Serve')) {
-                return new \App\Cdn\Resource\UrlGenerator\Serve($oSerice, $iObjectId);
+                return new \App\Cdn\Resource\UrlGenerator\Serve($oCdn, $oService, $iObjectId, $bForceDownload);
             } else {
-                return new Resource\UrlGenerator\Serve($oSerice, $iObjectId);
+                return new Resource\UrlGenerator\Serve($oCdn, $oService, $iObjectId, $bForceDownload);
             }
         },
     ],

--- a/src/Interfaces/UrlGenerator.php
+++ b/src/Interfaces/UrlGenerator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Nails\Cdn\Interfaces;
+
+use Nails\Cdn\Resource;
+use Nails\Cdn\Service;
+use Nails\Cdn\Interfaces;
+
+/**
+ * Interface UrlGenerator
+ *
+ * @package Nails\Cdn\Interfaces
+ */
+interface UrlGenerator
+{
+    /**
+     * UrlGenerator constructor.
+     *
+     * @param Service\Cdn          $oCdn      The CDN service
+     * @param Service\UrlGenerator $oService  The UrlGenerator service
+     * @param int                  $iObjectId The Object to generate the URL for
+     */
+    public function __construct(Service\Cdn $oCdn, Service\UrlGenerator $oService, int $iObjectId);
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Returns the Object ID
+     *
+     * @return int
+     */
+    public function getObjectId(): int;
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Determines whether the URL has been generated yet or not
+     *
+     * @return bool
+     */
+    public function isGenerated(): bool;
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates the URL
+     *
+     * @param Resource\CdnObject $oObject The Object Resource
+     *
+     * @return $this
+     */
+    public function generate(Resource\CdnObject $oObject): self;
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Calls the appropriate method on the driver
+     *
+     * @param Interfaces\Driver  $oDriver The driver instance
+     * @param Resource\CdnObject $oObject The Object Resource
+     *
+     * @return string
+     */
+    public function callDriver(Interfaces\Driver $oDriver, Resource\CdnObject $oObject): string;
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Triggers a URL generation and returns the cURL
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/src/Model/CdnObject/Trash.php
+++ b/src/Model/CdnObject/Trash.php
@@ -21,7 +21,7 @@ use Nails\Cdn\Model\CdnObject;
  */
 class Trash extends CdnObject
 {
-    const RESOURCE_NAME     = 'Object';
+    const RESOURCE_NAME     = 'ObjectTrash';
     const RESOURCE_PROVIDER = Constants::MODULE_SLUG;
 
     // --------------------------------------------------------------------------

--- a/src/Resource/CdnObject/Trash.php
+++ b/src/Resource/CdnObject/Trash.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nails\Cdn\Resource\CdnObject;
+
+use Nails\Cdn\Resource\CdnObject;
+
+/**
+ * Class Trash
+ *
+ * @package Nails\Cdn\Resource\CdnObject
+ */
+class Trash extends CdnObject
+{
+}

--- a/src/Resource/UrlGenerator.php
+++ b/src/Resource/UrlGenerator.php
@@ -15,7 +15,7 @@ use Nails\Factory;
  *
  * @package Nails\Cdn\Resource
  */
-abstract class UrlGenerator extends Resource implements Interfaces\UrlGenerator
+abstract class UrlGenerator extends Resource implements Interfaces\UrlGenerator, \JsonSerializable
 {
     /**
      * The CDN service
@@ -122,5 +122,19 @@ abstract class UrlGenerator extends Resource implements Interfaces\UrlGenerator
         }
 
         return $this->sUrl ?? '';
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * When serialised, return the URL ratehr than serialize the object
+     *
+     * @return string
+     * @throws FactoryException
+     * @throws ModelException
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }

--- a/src/Resource/UrlGenerator.php
+++ b/src/Resource/UrlGenerator.php
@@ -103,6 +103,10 @@ abstract class UrlGenerator extends Resource implements Interfaces\UrlGenerator,
 
         $this->sUrl = $this->callDriver($oDriver, $oObject);
 
+        if ($oObject instanceof CdnObject\Trash) {
+            $this->sUrl .= (strpos('?', $this->sUrl) !== false ? '&' : '?') . 'trashed=1';
+        }
+
         return $this;
     }
 

--- a/src/Resource/UrlGenerator.php
+++ b/src/Resource/UrlGenerator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Nails\Cdn\Resource;
+
+use Nails\Cdn\Interfaces;
+use Nails\Cdn\Service;
+use Nails\Common\Resource;
+
+abstract class UrlGenerator extends Resource
+{
+    protected $oService;
+    protected $iObjectId;
+
+    // --------------------------------------------------------------------------
+
+    public function __construct(Service\UrlGenerator $oService, int $iObjectId)
+    {
+        $this->oService  = $oService;
+        $this->iObjectId = $iObjectId;
+    }
+
+    public function __toString()
+    {
+        dd(static::class, 'TO STRING!');
+    }
+}

--- a/src/Resource/UrlGenerator.php
+++ b/src/Resource/UrlGenerator.php
@@ -2,25 +2,125 @@
 
 namespace Nails\Cdn\Resource;
 
+use Nails\Cdn\Constants;
 use Nails\Cdn\Interfaces;
 use Nails\Cdn\Service;
+use Nails\Common\Exception\FactoryException;
+use Nails\Common\Exception\ModelException;
 use Nails\Common\Resource;
+use Nails\Factory;
 
-abstract class UrlGenerator extends Resource
+/**
+ * Class UrlGenerator
+ *
+ * @package Nails\Cdn\Resource
+ */
+abstract class UrlGenerator extends Resource implements Interfaces\UrlGenerator
 {
+    /**
+     * The CDN service
+     *
+     * @var Service\Cdn
+     */
+    protected $oCdn;
+
+    /**
+     * The URL Generator service
+     *
+     * @var Service\UrlGenerator
+     */
     protected $oService;
+
+    /**
+     * The Object ID
+     *
+     * @var int
+     */
     protected $iObjectId;
+
+    /**
+     * The generated URL
+     *
+     * @var string
+     */
+    protected $sUrl;
 
     // --------------------------------------------------------------------------
 
-    public function __construct(Service\UrlGenerator $oService, int $iObjectId)
+    /**
+     * UrlGenerator constructor.
+     *
+     * @param Service\Cdn          $oCdn      The Cdn service
+     * @param Service\UrlGenerator $oService  The UrlGenerator service
+     * @param int                  $iObjectId The Object to generate the URL for
+     */
+    public function __construct(Service\Cdn $oCdn, Service\UrlGenerator $oService, int $iObjectId)
     {
+        $this->oCdn      = $oCdn;
         $this->oService  = $oService;
         $this->iObjectId = $iObjectId;
     }
 
+    // --------------------------------------------------------------------------
+
+    /**
+     * Returns the Object ID
+     *
+     * @return int
+     */
+    public function getObjectId(): int
+    {
+        return $this->iObjectId;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Determines whether the URL has been generated or not
+     *
+     * @return bool
+     */
+    public function isGenerated(): bool
+    {
+        return !is_null($this->sUrl);
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates the URL
+     *
+     * @param CdnObject $oObject The Object Resource
+     *
+     * @return Interfaces\UrlGenerator
+     * @throws FactoryException
+     */
+    public function generate(CdnObject $oObject): Interfaces\UrlGenerator
+    {
+        /** @var Service\StorageDriver $oStorageDriver */
+        $oStorageDriver = Factory::service('StorageDriver', Constants::MODULE_SLUG);
+        $oDriver        = $oStorageDriver->getInstance($oObject->driver);
+
+        $this->sUrl = $this->callDriver($oDriver, $oObject);
+
+        return $this;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates and returns the URL
+     *
+     * @return string
+     * @throws FactoryException
+     * @throws ModelException
+     */
     public function __toString()
     {
-        dd(static::class, 'TO STRING!');
+        if (!$this->isGenerated()) {
+            $this->oService->generate();
+        }
+
+        return $this->sUrl ?? '';
     }
 }

--- a/src/Resource/UrlGenerator/Crop.php
+++ b/src/Resource/UrlGenerator/Crop.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Nails\Cdn\Resource\UrlGenerator;
+
+use Nails\Cdn\Service;
+use Nails\Cdn\Resource\UrlGenerator;
+
+class Crop extends UrlGenerator
+{
+    protected $iWidth;
+    protected $iHeight;
+
+    // --------------------------------------------------------------------------
+
+    public function setWidth(int $iWidth): self
+    {
+        $this->iWidth = $iWidth;
+        return $this;
+    }
+
+    // --------------------------------------------------------------------------
+
+    public function setHeight(int $iHeight): self
+    {
+        $this->iHeight = $iHeight;
+        return $this;
+    }
+}

--- a/src/Resource/UrlGenerator/Crop.php
+++ b/src/Resource/UrlGenerator/Crop.php
@@ -2,27 +2,96 @@
 
 namespace Nails\Cdn\Resource\UrlGenerator;
 
+use Nails\Cdn\Constants;
+use Nails\Cdn\Exception;
+use Nails\Cdn\Interfaces;
+use Nails\Cdn\Resource;
 use Nails\Cdn\Service;
-use Nails\Cdn\Resource\UrlGenerator;
+use Nails\Factory;
 
-class Crop extends UrlGenerator
+/**
+ * Class Crop
+ *
+ * @package Nails\Cdn\Resource\UrlGenerator
+ */
+class Crop extends Resource\UrlGenerator
 {
+    /**
+     * The width of the crop
+     *
+     * @var int
+     */
     protected $iWidth;
+
+    /**
+     * the height of the crop
+     *
+     * @var int
+     */
     protected $iHeight;
 
     // --------------------------------------------------------------------------
 
-    public function setWidth(int $iWidth): self
-    {
-        $this->iWidth = $iWidth;
-        return $this;
+    /**
+     * Crop constructor.
+     *
+     * @param Service\Cdn          $oCdn      The Cdn service
+     * @param Service\UrlGenerator $oService  The UrlGenerator service
+     * @param int                  $iObjectId The Object to generate the URL for
+     * @param int|null             $iWidth    The width of the crop
+     * @param int|null             $iHeight   The height of the crop
+     */
+    public function __construct(
+        Service\Cdn $oCdn,
+        Service\UrlGenerator $oService,
+        int $iObjectId,
+        int $iWidth = null,
+        int $iHeight = null
+    ) {
+        parent::__construct($oCdn, $oService, $iObjectId);
+        $this->iWidth  = $iWidth ?? 100;
+        $this->iHeight = $iHeight ?? 100;
+
+        if (!$this->oCdn->isPermittedDimension($iWidth, $iHeight)) {
+            throw new Exception\PermittedDimensionException(
+                sprintf(
+                    '%s - Transformation of image to %sx%s is not permitted',
+                    static::class,
+                    $this->iWidth,
+                    $this->iHeight
+                )
+            );
+        }
     }
 
     // --------------------------------------------------------------------------
 
-    public function setHeight(int $iHeight): self
+    /**
+     * Calls the appropriate method on the driver
+     *
+     * @param Interfaces\Driver  $oDriver The driver instance
+     * @param Resource\CdnObject $oObject The Object Resource
+     *
+     * @return string
+     */
+    public function callDriver(Interfaces\Driver $oDriver, Resource\CdnObject $oObject): string
     {
-        $this->iHeight = $iHeight;
-        return $this;
+        $sCacheUrl = $this->oCdn::getCacheUrl(
+            $oObject->bucket->slug,
+            $oObject->file->name->disk,
+            $oObject->file->ext,
+            'CROP',
+            $oObject->img->orientation ?? null,
+            $this->iWidth,
+            $this->iHeight
+        );
+
+        return $sCacheUrl
+            ?? $oDriver->urlCrop(
+                $oObject->file->name->disk,
+                $oObject->bucket->slug,
+                $this->iWidth,
+                $this->iHeight
+            );
     }
 }

--- a/src/Resource/UrlGenerator/Crop.php
+++ b/src/Resource/UrlGenerator/Crop.php
@@ -76,15 +76,17 @@ class Crop extends Resource\UrlGenerator
      */
     public function callDriver(Interfaces\Driver $oDriver, Resource\CdnObject $oObject): string
     {
-        $sCacheUrl = $this->oCdn::getCacheUrl(
-            $oObject->bucket->slug,
-            $oObject->file->name->disk,
-            $oObject->file->ext,
-            'CROP',
-            $oObject->img->orientation ?? null,
-            $this->iWidth,
-            $this->iHeight
-        );
+        if ($oObject instanceof Resource\CdnObject\Trash && userHasPermission('admin:cdn:trash:browse')) {
+            $sCacheUrl = $this->oCdn::getCacheUrl(
+                $oObject->bucket->slug,
+                $oObject->file->name->disk,
+                $oObject->file->ext,
+                'CROP',
+                $oObject->img->orientation ?? null,
+                $this->iWidth,
+                $this->iHeight
+            );
+        }
 
         return $sCacheUrl
             ?? $oDriver->urlCrop(

--- a/src/Resource/UrlGenerator/Scale.php
+++ b/src/Resource/UrlGenerator/Scale.php
@@ -2,8 +2,37 @@
 
 namespace Nails\Cdn\Resource\UrlGenerator;
 
+use Nails\Cdn\Interfaces;
+use Nails\Cdn\Resource;
 use Nails\Cdn\Service;
 
 class Scale extends Crop
 {
+    /**
+     * Calls the appropriate method on the driver
+     *
+     * @param Interfaces\Driver  $oDriver The driver instance
+     * @param Resource\CdnObject $oObject The Object Resource
+     *
+     * @return string
+     */
+    public function callDriver(Interfaces\Driver $oDriver, Resource\CdnObject $oObject): string
+    {
+        $sCacheUrl = $this->oCdn::getCacheUrl(
+            $oObject->bucket->slug,
+            $oObject->file->name->disk,
+            $oObject->file->ext,
+            'CROP',
+            $oObject->img->orientation ?? null,
+            $this->iWidth,
+            $this->iHeight
+        );
+
+        return $oDriver->urlScale(
+            $oObject->file->name->disk,
+            $oObject->bucket->slug,
+            $this->iWidth,
+            $this->iHeight
+        );
+    }
 }

--- a/src/Resource/UrlGenerator/Scale.php
+++ b/src/Resource/UrlGenerator/Scale.php
@@ -18,15 +18,17 @@ class Scale extends Crop
      */
     public function callDriver(Interfaces\Driver $oDriver, Resource\CdnObject $oObject): string
     {
-        $sCacheUrl = $this->oCdn::getCacheUrl(
-            $oObject->bucket->slug,
-            $oObject->file->name->disk,
-            $oObject->file->ext,
-            'CROP',
-            $oObject->img->orientation ?? null,
-            $this->iWidth,
-            $this->iHeight
-        );
+        if ($oObject instanceof Resource\CdnObject\Trash && userHasPermission('admin:cdn:trash:browse')) {
+            $sCacheUrl = $this->oCdn::getCacheUrl(
+                $oObject->bucket->slug,
+                $oObject->file->name->disk,
+                $oObject->file->ext,
+                'SCALE',
+                $oObject->img->orientation ?? null,
+                $this->iWidth,
+                $this->iHeight
+            );
+        }
 
         return $oDriver->urlScale(
             $oObject->file->name->disk,

--- a/src/Resource/UrlGenerator/Scale.php
+++ b/src/Resource/UrlGenerator/Scale.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Nails\Cdn\Resource\UrlGenerator;
+
+use Nails\Cdn\Service;
+
+class Scale extends Crop
+{
+}

--- a/src/Resource/UrlGenerator/Serve.php
+++ b/src/Resource/UrlGenerator/Serve.php
@@ -2,9 +2,50 @@
 
 namespace Nails\Cdn\Resource\UrlGenerator;
 
+use Nails\Cdn\Interfaces;
+use Nails\Cdn\Resource;
 use Nails\Cdn\Service;
-use Nails\Cdn\Resource\UrlGenerator;
 
-class Serve extends UrlGenerator
+class Serve extends Resource\UrlGenerator
 {
+    protected $bForceDownload;
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Serve constructor.
+     *
+     * @param Service\Cdn          $oCdn           The Cdn service
+     * @param Service\UrlGenerator $oService       The UrlGenerator service
+     * @param int                  $iObjectId      The Object to generate the URL for
+     * @param bool                 $bForceDownload Whether to force a download, or not
+     */
+    public function __construct(
+        Service\Cdn $oCdn,
+        Service\UrlGenerator $oService,
+        int $iObjectId,
+        bool $bForceDownload = false
+    ) {
+        parent::__construct($oCdn, $oService, $iObjectId);
+        $this->bForceDownload = $bForceDownload;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Calls the appropriate method on the driver
+     *
+     * @param Interfaces\Driver  $oDriver The driver instance
+     * @param Resource\CdnObject $oObject The Object Resource
+     *
+     * @return string
+     */
+    public function callDriver(Interfaces\Driver $oDriver, Resource\CdnObject $oObject): string
+    {
+        return $oDriver->urlServe(
+            $oObject->file->name->disk,
+            $oObject->bucket->slug,
+            $this->bForceDownload
+        );
+    }
 }

--- a/src/Resource/UrlGenerator/Serve.php
+++ b/src/Resource/UrlGenerator/Serve.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Nails\Cdn\Resource\UrlGenerator;
+
+use Nails\Cdn\Service;
+use Nails\Cdn\Resource\UrlGenerator;
+
+class Serve extends UrlGenerator
+{
+}

--- a/src/Service/Cdn.php
+++ b/src/Service/Cdn.php
@@ -1018,7 +1018,7 @@ class Cdn
 
             if (in_array($oData->mime, $aImageMimeTypes)) {
 
-                list($iWidth, $iHeight) = getimagesize($oData->file);
+                [$iWidth, $iHeight] = getimagesize($oData->file);
                 $oData->img = (object) [
                     'width'       => $iWidth,
                     'height'      => $iHeight,
@@ -2251,6 +2251,11 @@ class Cdn
      */
     public function urlServe($iObjectId, $bForceDownload = false)
     {
+        /** @var UrlGenerator $oUrlService */
+        $oUrlService = Factory::service('UrlGenerator', Constants::MODULE_SLUG);
+
+        return $iObjectId ? $oUrlService->serve($iObjectId) : null;
+
         //  Test the cache first, have we dealt with this url yet?
         if (is_object($iObjectId)) {
             $sCacheKey = 'URL:SERVE:' . $iObjectId->id . ':' . (int) $bForceDownload;
@@ -2474,6 +2479,11 @@ class Cdn
      **/
     public function urlCrop($iObjectId, $iWidth, $iHeight)
     {
+        /** @var UrlGenerator $oUrlService */
+        $oUrlService = Factory::service('UrlGenerator', Constants::MODULE_SLUG);
+
+        return $iObjectId ? $oUrlService->crop($iObjectId) : null;
+
         //  Test the cache first, have we dealt with this url yet?
         if (is_object($iObjectId)) {
             $sCacheKey = 'URL:CROP:' . $iObjectId->id . ':' . $iWidth . ':' . $iHeight;
@@ -2585,6 +2595,11 @@ class Cdn
      **/
     public function urlScale($iObjectId, $iWidth, $iHeight)
     {
+        /** @var UrlGenerator $oUrlService */
+        $oUrlService = Factory::service('UrlGenerator', Constants::MODULE_SLUG);
+
+        return $iObjectId ? $oUrlService->scale($iObjectId) : null;
+
         //  Test the cache first, have we dealt with this url yet?
         if (is_object($iObjectId)) {
             $sCacheKey = 'URL:SCALE:' . $iObjectId->id . ':' . $iWidth . ':' . $iHeight;

--- a/src/Service/Cdn.php
+++ b/src/Service/Cdn.php
@@ -2247,10 +2247,10 @@ class Cdn
      * @param int  $iObjectId      The ID of the object to serve
      * @param bool $bForceDownload Whether or not to force download of the object
      *
-     * @return Resource\UrlGenerator\Crop
+     * @return Resource\UrlGenerator\Crop|null
      * @throws UrlException
      */
-    public function urlServe($iObjectId, $bForceDownload = false): Resource\UrlGenerator\Serve
+    public function urlServe($iObjectId, $bForceDownload = false): ?Resource\UrlGenerator\Serve
     {
         /** @var UrlGenerator $oUrlService */
         $oUrlService = Factory::service('UrlGenerator', Constants::MODULE_SLUG);
@@ -2420,9 +2420,9 @@ class Cdn
      * @param int $iWidth    The width of the crop
      * @param int $iHeight   The height of the crop
      *
-     * @return Resource\UrlGenerator\Crop
+     * @return Resource\UrlGenerator\Crop|null
      **/
-    public function urlCrop($iObjectId, $iWidth, $iHeight): Resource\UrlGenerator\Crop
+    public function urlCrop($iObjectId, $iWidth, $iHeight): ?Resource\UrlGenerator\Crop
     {
         /** @var UrlGenerator $oUrlService */
         $oUrlService = Factory::service('UrlGenerator', Constants::MODULE_SLUG);
@@ -2453,9 +2453,9 @@ class Cdn
      * @param int $iWidth    The width of the scaled image
      * @param int $iHeight   The height of the scaled image
      *
-     * @return Resource\UrlGenerator\Scale
+     * @return Resource\UrlGenerator\Scale|null
      **/
-    public function urlScale($iObjectId, $iWidth, $iHeight): Resource\UrlGenerator\Scale
+    public function urlScale($iObjectId, $iWidth, $iHeight): ?Resource\UrlGenerator\Scale
     {
         /** @var UrlGenerator $oUrlService */
         $oUrlService = Factory::service('UrlGenerator', Constants::MODULE_SLUG);

--- a/src/Service/UrlGenerator.php
+++ b/src/Service/UrlGenerator.php
@@ -56,13 +56,18 @@ class UrlGenerator
     {
         if (is_object($mObject)) {
             $mObject = $mObject->id;
-        } elseif (!is_int($mObject)) {
+        } elseif (!is_numeric($mObject)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    'Second argument passed to %s must be an object, or an integer',
-                    __METHOD__
+                    'Second argument passed to %s must be an object, or an integer; %s passed',
+                    __METHOD__,
+                    gettype($mObject)
                 )
             );
+        }
+
+        if (!is_int($mObject) && is_numeric($mObject)) {
+            $mObject = (int) $mObject;
         }
 
         $aArgs = func_get_args();

--- a/src/Service/UrlGenerator.php
+++ b/src/Service/UrlGenerator.php
@@ -3,82 +3,187 @@
 namespace Nails\Cdn\Service;
 
 use Nails\Cdn\Constants;
+use Nails\Cdn\Model\CdnObject;
 use Nails\Cdn\Resource;
+use Nails\Common\Exception\FactoryException;
+use Nails\Common\Exception\ModelException;
+use Nails\Common\Helper\Model\Expand;
 use Nails\Common\Traits\Caching;
 use Nails\Factory;
 
+/**
+ * Class UrlGenerator
+ *
+ * @package Nails\Cdn\Service
+ */
 class UrlGenerator
 {
-    use Caching;
-
-    // --------------------------------------------------------------------------
-
+    /**
+     * The resource names for the various sub-classes
+     */
     const RESOURCE_CROP  = 'UrlGeneratorCrop';
     const RESOURCE_SCALE = 'UrlGeneratorScale';
     const RESOURCE_SERVE = 'UrlGeneratorServe';
 
     // --------------------------------------------------------------------------
 
-    protected $aTouchedObjectIds = [];
+    /**
+     * The generators which have been created
+     *
+     * @var Resource\UrlGenerator[]
+     */
+    protected $aGenerators = [];
+
+    /**
+     * The Object resources which have been fetched
+     *
+     * @var Resource\CdnObject[]
+     */
+    protected $aCachedObjects = [];
 
     // --------------------------------------------------------------------------
 
-    protected function build(int $iObjectId, string $sResource): Resource\UrlGenerator
+    /**
+     * Returns a new Generator
+     *
+     * @param string     $sResource The type of generator to build
+     * @param object|int $mObject   The object ID, or resource
+     *
+     * @return Resource\UrlGenerator
+     * @throws \InvalidArgumentException
+     */
+    protected function build(string $sResource, $mObject): Resource\UrlGenerator
     {
-        if (!in_array($iObjectId, $this->aTouchedObjectIds)) {
-            $this->aTouchedObjectIds[] = $iObjectId;
+        if (is_object($mObject)) {
+            $mObject = $mObject->id;
+        } elseif (!is_int($mObject)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Second argument passed to %s must be an object, or an integer',
+                    __METHOD__
+                )
+            );
         }
 
-        $sKacheKey = sprintf('OBJECT:%s:%s', $sResource, $iObjectId);
-        $oCached   = $this->getCache($sKacheKey);
-        if ($oCached) {
-            return $oCached;
-        }
-
-        /** @var Resource\UrlGenerator $oGenerator */
-        $oGenerator = Factory::resource(
-            $sResource,
-            Constants::MODULE_SLUG,
-            $this,
-            $iObjectId
+        $aArgs = func_get_args();
+        array_shift($aArgs);
+        array_shift($aArgs);
+        $aArgs = array_merge(
+            [
+                $sResource,
+                Constants::MODULE_SLUG,
+                Factory::service('Cdn', Constants::MODULE_SLUG),
+                $this,
+                $mObject,
+            ],
+            $aArgs
         );
 
-        $this->setCache($sKacheKey, $oGenerator);
+        /** @var Resource\UrlGenerator $oGenerator */
+        $oGenerator = call_user_func_array(
+            '\Nails\Factory::resource',
+            $aArgs
+        );
+
+        $this->aGenerators[] = $oGenerator;
         return $oGenerator;
     }
 
     // --------------------------------------------------------------------------
 
-    public function crop(int $iObjectId, int $iWidth, int $iHeight): Resource\UrlGenerator\Crop
+    /**
+     * Returns a new Crop Generator
+     *
+     * @param object|int $mObject The object ID, or resource
+     * @param int        $iWidth  The width of the URL
+     * @param int        $iHeight The height of the URL
+     *
+     * @return Resource\UrlGenerator\Crop
+     * @throws \InvalidArgumentException
+     */
+    public function crop($mObject, int $iWidth, int $iHeight): Resource\UrlGenerator\Crop
     {
         /** @var Resource\UrlGenerator\Crop $oGenerator */
-        $oGenerator = $this->build($iObjectId, static::RESOURCE_CROP);
-        $oGenerator
-            ->setWidth($iWidth)
-            ->setHeight($iHeight);
-
+        $oGenerator = $this->build(static::RESOURCE_CROP, $mObject, $iWidth, $iHeight);
         return $oGenerator;
     }
 
     // --------------------------------------------------------------------------
 
-    public function scale(int $iObjectId, int $iWidth, int $iHeight): Resource\UrlGenerator\Scale
+    /**
+     * Returns a new Scale Generator
+     *
+     * @param object|int $mObject The object ID, or resource
+     * @param int        $iWidth  The width of the URL
+     * @param int        $iHeight The height of the URL
+     *
+     * @return Resource\UrlGenerator\Crop
+     * @throws \InvalidArgumentException
+     */
+    public function scale($mObject, int $iWidth, int $iHeight): Resource\UrlGenerator\Scale
     {
         /** @var Resource\UrlGenerator\Scale $oGenerator */
-        $oGenerator = $this->build($iObjectId, static::RESOURCE_SCALE);
-        $oGenerator
-            ->setWidth($iWidth)
-            ->setHeight($iHeight);
-
+        $oGenerator = $this->build(static::RESOURCE_SCALE, $mObject, $iWidth, $iHeight);
         return $oGenerator;
     }
 
     // --------------------------------------------------------------------------
 
-    public function serve(int $iObjectId): Resource\UrlGenerator\Serve
+    /**
+     * Returns a new Serve Generator
+     *
+     * @param object|int $mObject        The object ID, or resource
+     * @param bool       $bForceDownload Whether to force a download, or not
+     *
+     * @return Resource\UrlGenerator\Crop
+     * @throws \InvalidArgumentException
+     */
+    public function serve($mObject, bool $bForceDownload = false): Resource\UrlGenerator\Serve
     {
         /** @var Resource\UrlGenerator\Serve $oGenerator */
-        $oGenerator = $this->build($iObjectId, static::RESOURCE_SERVE);
+        $oGenerator = $this->build(static::RESOURCE_SERVE, $mObject, $bForceDownload);
         return $oGenerator;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * @throws FactoryException
+     * @throws ModelException
+     */
+    public function generate()
+    {
+        $aObjectIds = [];
+        foreach ($this->aGenerators as $oUrlObject) {
+            if (!$oUrlObject->isGenerated()) {
+                $aObjectIds[] = $oUrlObject->getObjectId();
+            }
+        }
+
+        $aObjectIds = array_unique($aObjectIds);
+        $aObjectIds = array_filter($aObjectIds);
+        $aObjectIds = array_values($aObjectIds);
+
+        //  Only fetch new items from the DB
+        $aCachedIds = arrayExtractProperty($this->aCachedObjects, 'id');
+        $aNewIds    = array_diff($aObjectIds, $aCachedIds);
+
+        if (!empty($aNewIds)) {
+            /** @var CdnObject $oObjectModel */
+            $oObjectModel = Factory::model('Object', Constants::MODULE_SLUG);
+            foreach ($oObjectModel->getByIds($aObjectIds, [new Expand('bucket')]) as $oObject) {
+                $this->aCachedObjects[$oObject->id] = $oObject;
+            }
+        }
+
+        //  @todo (Pablo - 2020-02-25) - Fetch items from trash if needed
+
+        foreach ($this->aGenerators as $oUrlObject) {
+            if (in_array($oUrlObject->getObjectId(), $aObjectIds)) {
+                $oUrlObject->generate(
+                    $this->aCachedObjects[$oUrlObject->getObjectId()]
+                );
+            }
+        }
     }
 }

--- a/src/Service/UrlGenerator.php
+++ b/src/Service/UrlGenerator.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Nails\Cdn\Service;
+
+use Nails\Cdn\Constants;
+use Nails\Cdn\Resource;
+use Nails\Common\Traits\Caching;
+use Nails\Factory;
+
+class UrlGenerator
+{
+    use Caching;
+
+    // --------------------------------------------------------------------------
+
+    const RESOURCE_CROP  = 'UrlGeneratorCrop';
+    const RESOURCE_SCALE = 'UrlGeneratorScale';
+    const RESOURCE_SERVE = 'UrlGeneratorServe';
+
+    // --------------------------------------------------------------------------
+
+    protected $aTouchedObjectIds = [];
+
+    // --------------------------------------------------------------------------
+
+    protected function build(int $iObjectId, string $sResource): Resource\UrlGenerator
+    {
+        if (!in_array($iObjectId, $this->aTouchedObjectIds)) {
+            $this->aTouchedObjectIds[] = $iObjectId;
+        }
+
+        $sKacheKey = sprintf('OBJECT:%s:%s', $sResource, $iObjectId);
+        $oCached   = $this->getCache($sKacheKey);
+        if ($oCached) {
+            return $oCached;
+        }
+
+        /** @var Resource\UrlGenerator $oGenerator */
+        $oGenerator = Factory::resource(
+            $sResource,
+            Constants::MODULE_SLUG,
+            $this,
+            $iObjectId
+        );
+
+        $this->setCache($sKacheKey, $oGenerator);
+        return $oGenerator;
+    }
+
+    // --------------------------------------------------------------------------
+
+    public function crop(int $iObjectId, int $iWidth, int $iHeight): Resource\UrlGenerator\Crop
+    {
+        /** @var Resource\UrlGenerator\Crop $oGenerator */
+        $oGenerator = $this->build($iObjectId, static::RESOURCE_CROP);
+        $oGenerator
+            ->setWidth($iWidth)
+            ->setHeight($iHeight);
+
+        return $oGenerator;
+    }
+
+    // --------------------------------------------------------------------------
+
+    public function scale(int $iObjectId, int $iWidth, int $iHeight): Resource\UrlGenerator\Scale
+    {
+        /** @var Resource\UrlGenerator\Scale $oGenerator */
+        $oGenerator = $this->build($iObjectId, static::RESOURCE_SCALE);
+        $oGenerator
+            ->setWidth($iWidth)
+            ->setHeight($iHeight);
+
+        return $oGenerator;
+    }
+
+    // --------------------------------------------------------------------------
+
+    public function serve(int $iObjectId): Resource\UrlGenerator\Serve
+    {
+        /** @var Resource\UrlGenerator\Serve $oGenerator */
+        $oGenerator = $this->build($iObjectId, static::RESOURCE_SERVE);
+        return $oGenerator;
+    }
+}


### PR DESCRIPTION
This PR introduces Just-in-time URL generation for crop, scale, and serve URLs. This allows multiple calls to `cdn*` methods to be used with no database or driver impact until the URLs are actually needed.