### PR TITLE
Support Attributes in Picture helper

### DIFF
--- a/src/Helper/Picture.php
+++ b/src/Helper/Picture.php
@@ -35,25 +35,30 @@ class Picture
     /** @var string */
     protected $sAlt;
 
+    /** @var string[string] */
+    protected $aAttributes;
+
     // --------------------------------------------------------------------------
 
     /**
      * Picture constructor.
      *
-     * @param int|CdnObject $mCdnObject
-     * @param int           $iFallbackWidth
-     * @param int           $iFallbackHeight
-     * @param string        $sAlt
-     * @param Cdn|null      $oCdn
+     * @param int|CdnObject  $mCdnObject
+     * @param int            $iFallbackWidth
+     * @param int            $iFallbackHeight
+     * @param string         $sAlt
+     * @param Cdn|null       $oCdn
+     * @param string[string] $aAttributes
      *
      * @throws FactoryException
      */
-    public function __construct($mCdnObject, int $iFallbackWidth, int $iFallbackHeight, string $sAlt, Cdn $oCdn = null)
+    public function __construct($mCdnObject, int $iFallbackWidth, int $iFallbackHeight, string $sAlt, Cdn $oCdn = null, array $aAttributes = [])
     {
         $this->iFallbackWidth  = $iFallbackWidth;
         $this->iFallbackHeight = $iFallbackHeight;
         $this->sAlt            = $sAlt;
         $this->oCdn            = $oCdn ?? Factory::service('Cdn', Constants::MODULE_SLUG);
+        $this->aAttributes     = $aAttributes;
 
         if (is_int($mCdnObject)) {
             $this->iCdnObjectId = $mCdnObject;
@@ -138,14 +143,34 @@ class Picture
     protected function generateFallbackMarkup(): string
     {
         return sprintf(
-            '<img src="%s" alt="%s" />',
+            '<img src="%s" %s/>',
             $this->oCdn->urlCrop(
                 $this->iCdnObjectId,
                 $this->iFallbackWidth,
                 $this->iFallbackHeight
             ),
-            $this->sAlt
+            $this->generateAttributes()
         );
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates attributes for img markup
+     *
+     * @return string
+     */
+    protected function generateAttributes(): string
+    {
+        $aAttributes = array_filter([
+            $this->sAlt ? 'alt="' . $this->sAlt . '"' : null
+        ]);
+
+        foreach ($this->aAttributes as $key => $val) {
+            $aAttributes[] = $key . '="' . $val . '"';
+        }
+
+        return implode(" ", $aAttributes);
     }
 
     // --------------------------------------------------------------------------


### PR DESCRIPTION
What this does
Allows the user to add arbitrary attributes to the picture->img tag in the responsive Picture helper, primarily to support the addition of `loading="lazy"` tags